### PR TITLE
charger: Show all charger animations

### DIFF
--- a/healthd/healthd_mode_charger.cpp
+++ b/healthd/healthd_mode_charger.cpp
@@ -156,7 +156,7 @@ static struct frame batt_anim_frames[] = {
     {
         .disp_time = 750,
         .min_capacity = 80,
-        .level_only = true,
+        .level_only = false,
         .surface = NULL,
     },
     {


### PR DESCRIPTION
With level-only set to true 80% battery animation is
only shown when battery is exactly 80%. Set to false
to allow all animation frames to be used.

Change-Id: I7b53e924a661e644ad00ba9906e582d4a6bc2610
